### PR TITLE
Standardize alerter engines.

### DIFF
--- a/zk_monitor/alerts/base.py
+++ b/zk_monitor/alerts/base.py
@@ -30,17 +30,20 @@ class AlerterBase(object):
         # classes that inherit this method.
         log.debug('Initializing Alerter "%s"' % self.__class__.__name__)
 
-    def alert(self, message, params=None):
+    def alert(self, path, state, message, params):
         """Fires off an Alert.
 
         args:
-            message: String to send
+            path: String of the path that is being alerted.
+            state: String of the monitor.states for given path.
+            message: String of details regarding this state.
             params: Dictionary of arbitrary parameters needed for specific
-                    alert type.
+                    alert type. For `email` it would be the address, for
+                    HipChat it would be the room id
         """
         # Using __class__.__name__ here to specify the name of the child
         # classes that inherit this method.
         log.warning('Firing Alert of type `%s` with "%s"' % (
             self.__class__.__name__, message))
 
-        self._alert(message, params=params)
+        self._alert(path, state, message, params)

--- a/zk_monitor/alerts/dispatcher.py
+++ b/zk_monitor/alerts/dispatcher.py
@@ -74,15 +74,21 @@ class Dispatcher(object):
             1) Create a pending alert status
             2) Wait to see if it gets cancelled
             3) Check the status and alert.
+
+        Args:
+            path: String of zk path that is being updated.
+            state: monitor.states - the new path state.
+            reason: String - message explaining why the state is updated.
         """
-        # import monitor here? otherwise circular loop
+        self._path_status(path, message=reason, state=state)
+
         if state == states.OK:
             # Cancel the alert and bail out of here.
-            self._path_status(path, message=reason, next_action=actions.NONE)
+            self._path_status(path, next_action=actions.NONE)
             raise gen.Return()
 
         # Set the alert, and continue to check your timer
-        self._path_status(path, message=reason, next_action=actions.ALERT)
+        self._path_status(path, next_action=actions.ALERT)
 
         # Check if we should timeout
         config = self._config[path]
@@ -127,50 +133,51 @@ class Dispatcher(object):
 
     def send_alerts(self, path):
         """Send alert regarding this data."""
+        # Here 'message' explains why the alert was fired off.
+        # We use that as the details of the message.
         message = self._path_status(path)['message']
+        state = self._path_status(path)['state']
 
         config = self._config[path]
         for alert_type, params in config['alerter'].items():
             alert_engine = self.alerts.get(alert_type, None)
 
             if not alert_engine:
-                log.error('Alert type `%s` specified '
-                          'but not available' % alert_type)
+                log.warning('Alerter engine "%s" specified '
+                            'but not available to dispatcher.' % alert_type)
                 continue
 
             log.debug('Invoking alert type `%s`.' % alert_type)
 
-            # Making `body` optional. `message` is used as subject by the email
-            # engine.
-            body = config['alerter'].get('body', message)
+            alert_engine.alert(
+                path=path,
+                state=state,
+                message=message,
+                params=params)
 
-            # NOTE: Assuming email engine here until we can generalize it.
-
-            email_params = {'body': body,
-                            'email': config['alerter']['email']}
-            alert_engine.alert(message=message,
-                               params=email_params)
-
-    def _path_status(self, path, message=None, next_action=None):
+    def _path_status(self, path, **kwargs):
         """Get or create meta data for specific data path.
 
         Args:
-            path: Some zk registered path /foo
-            message: Human readable message/reason for an action.
-            next_action: alerts.actions value
+            path: string - some zk registered path /foo
+            kwargs: dictionary can be anything but here are some common keys:
+                state: monitor.states value.
+                message: reason for this state / message along with the action.
+                next_action: alerts.actions value.
         """
 
         if path not in self._live_path_status:
             self._live_path_status[path] = {
+                'state': states.UNKNOWN,
                 'message': False,
                 'next_action': None}
 
+        # Update local knowledge of the path metadata with any arbitrary
+        # keywords that were passed in
         path_data = self._live_path_status[path]
-        if message:
-            path_data['message'] = message
 
-        if next_action:
-            path_data['next_action'] = next_action
+        if kwargs:
+            path_data.update(kwargs)
 
         return path_data
 

--- a/zk_monitor/alerts/email.py
+++ b/zk_monitor/alerts/email.py
@@ -47,32 +47,36 @@ class EmailAlerter(base.AlerterBase):
 
         return self._saved_mail_backend
 
-    def _alert(self, message, params):
+    def _alert(self, path, state, message, params):
         """Send an email alert.
 
         args:
-            message: Main message contents.
-            params: A dictionary containing additional message params:
-              { 'email': <email address to send alert to>,
-                'body': <full message body> }
+            path: String of the path that is being alerted.
+            state: String of the monitor.states for given path.
+            message: String of details regarding this state.
+            params: Arbitrary data supplied by the configuration file for this
+                    alerter. Currently expecting a string of the address.
         """
-        subject = message
-        try:
-            body = params['body']
-            email = params['email']
-        except (TypeError, KeyError):
-            log.debug('Invalid configuration passed: %s' % params)
+        to_address = params
+        if not to_address:
+            log.error('Invalid email address from params: %s' % params)
             return
+
+        # Subject should not be status or message dependent to allow for proper
+        # email threading.
+        subject = "Warning! %s has an alert!" % path
+
+        # Body can be descriptive!
+        body = '%s\n%s is in the %s state.' % (message, path, state)
 
         # Create the Alert object. The object takes care of everything from
         # here so we store no reference to it (and let it get garbage
         # collected on its own later)
         log.debug('Creating Email Alert Message: %s' % message)
-        log.debug('Creating Email Alert with: %s' % EmailAlert)
         EmailAlert(
             subject=subject,
             body=body,
-            email=email,
+            email=to_address,
             conn=self._mail_backend)
 
 

--- a/zk_monitor/alerts/test/test_base.py
+++ b/zk_monitor/alerts/test/test_base.py
@@ -16,7 +16,8 @@ class TestBaseAlerter(unittest.TestCase):
         self.alerter._alert = mock.MagicMock()
 
         # Fire off an alert?
-        self.alerter.alert('unittest')
+        self.alerter.alert('path', 'state', 'message', 'params')
 
         # Now validate that only one alert was sent
-        self.alerter._alert.assert_called_once_with('unittest', params=None)
+        self.alerter._alert.assert_called_once_with(
+            'path', 'state', 'message', 'params')

--- a/zk_monitor/alerts/test/test_email.py
+++ b/zk_monitor/alerts/test/test_email.py
@@ -16,20 +16,14 @@ class TestEmailAlerter(unittest.TestCase):
     @mock.patch('zk_monitor.alerts.email.EmailAlert')
     def testAlert(self, mocked_alert, mocked_backend):
         backend_instance = mocked_backend.return_value
-        params = {
-            'body': 'Unit Test Body',
-            'email': 'unit@test.com',
-        }
-        self.alerter._alert('Unit Test Message', params)
+
+        self.alerter._alert('/foo', 'Broken',
+                            'Unit Test Message', 'unit@test.com')
         mocked_alert.assert_called_with(
-            subject='Unit Test Message',
-            body='Unit Test Body',
+            subject='Warning! /foo has an alert!',
+            body='Unit Test Message\n/foo is in the Broken state.',
             email='unit@test.com',
             conn=backend_instance)
-
-    def testAlertWithBadParams(self):
-        self.assertEquals(None, self.alerter.alert('unittest', params=None))
-        self.assertEquals(None, self.alerter.alert('unittest', params={}))
 
     def testSingleBackend(self):
         once = self.alerter._mail_backend


### PR DESCRIPTION
- Each engine receives the following data:
  - `path`: zk path that is alerting.
  - `state`: the state that is being alerted.
  - `message`: reason generated for given state.
  - `params`: arbitrary data from the config (yaml) for the given alert.

With this setup engines like Email or Hipchat can manipulate the data enough to construct a well-read subject/body/notification.
