### PR TITLE
Closes #18: Only 1 dispatcher should alert!

### DIFF
--- a/zk_monitor/alerts/dispatcher.py
+++ b/zk_monitor/alerts/dispatcher.py
@@ -147,7 +147,12 @@ class Dispatcher(object):
         raise gen.Return()
 
     def send_alerts(self, path):
-        """Send alert regarding this data."""
+        """Send alert regarding this path."""
+
+        if not self._lock.status():
+            log.debug('Not the primary dispatcher; not sending alerts.')
+            return False
+
         # Here 'message' explains why the alert was fired off.
         # We use that as the details of the message.
         message = self._path_status(path)['message']

--- a/zk_monitor/alerts/test/test_dispatcher.py
+++ b/zk_monitor/alerts/test/test_dispatcher.py
@@ -157,6 +157,24 @@ class TestDispatcher(testing.AsyncTestCase):
             path='/bar', state='Unknown', message='unittest',
             params=self.config['/bar']['alerter']['custom'])
 
+    def test_not_send_alerts(self):
+        """Dispatcher should check if it's the alerting type."""
+
+        path = '/bar'
+        bad_cs = mock.MagicMock()
+        bad_cs.getLock().status.return_value = False
+        self.dispatcher = dispatcher.Dispatcher(bad_cs, self.config)
+        self.dispatcher.alerts['email'] = mock.MagicMock()
+
+        # Set data, and send the alert
+        self.dispatcher._path_status(path, message='unittest')
+        ret = self.dispatcher.send_alerts(path)
+
+        self.assertFalse(ret)  # Did not send anything!
+
+        # Email...
+        self.dispatcher.alerts['email'].alert.assert_not_called()
+
     def test_lock(self):
         """Only one dispatcher should fire off alerts."""
 


### PR DESCRIPTION
We've been creating an alerting lock, but forgot to use it. This commit
forces dispatcher to check its alerting status before sending them.
